### PR TITLE
Support specifying record/replay configuration for which tests to cre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Configuration objects can have the following properties:
 
 * `titleFilters`: An array of strings containing patterns for the titles of tests to record, whether they passed or not.
 
-* `shuffleOrder`: Set to randomize the order in which tests will be recorded, and which tests will be selected to record if there are more than the maximum number allowed.
+* `randomize`: Set to randomize which tests will be selected to record if there are more than the maximum number allowed. This is useful to improve coverage in CI environments when there are many tests which could be recorded.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This is an alternative to Cypress that runs tests in the same way as the upstream Cypress library, and adds support for recording tests using replay enabled browsers.  By default, recordings will only be created for failing tests when using `cypress run`.  The `RECORD_REPLAY_API_KEY` environment variable must be set in order to record and upload tests.
+This is an alternative to Cypress that runs tests in the same way as the upstream Cypress library, and adds support for recording tests using replay enabled browsers.
 
 ## Install
 
@@ -17,3 +17,19 @@ npm install --save-dev @recordreplay/cypress
 ## Documentation
 
 Visit the [Cypress documentation](https://on.cypress.io/cli) for a full list of commands and examples.
+
+Recordings will only be created when using `cypress run`, and not `cypress open`.  The `RECORD_REPLAY_API_KEY` environment variable must be set in order to record and upload tests.
+
+By default, recordings will only be created for failing tests, and at most 20 recordings will be created in one test run. Each recording takes a minute or so to create and upload.
+
+To override this default behavior, a configuration JSON object can be specified with additional options. This can be specified either via the value of the `RECORD_REPLAY_CYPRESS_CONFIGURATION` environment variable, or in a file referenced by the `RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE` environment variable.
+
+Configuration objects can have the following properties:
+
+* `maxRecordings`: A number overriding the maximum number of recordings which can be created in one test run.
+
+* `recordAll`: Set to record all tests, up to the maximum number of recordings allowed.
+
+* `titleFilters`: An array of strings containing patterns for the titles of tests to record, whether they passed or not.
+
+* `shuffleOrder`: Set to randomize the order in which tests will be recorded, and which tests will be selected to record if there are more than the maximum number allowed.

--- a/lib/exec/run.js
+++ b/lib/exec/run.js
@@ -262,7 +262,7 @@ async function maybeRecordTests(options, testOutput) {
 
   let testRecordings = tests.filter(testInfo => shouldRecordTest(testInfo, configuration));
 
-  if (configuration.shuffleOrder) {
+  if (configuration.randomize) {
     testRecordings = _.shuffle(testRecordings);
   }
 
@@ -280,19 +280,23 @@ async function maybeRecordTests(options, testOutput) {
 }
 
 function loadRecordReplayConfiguration() {
-  try {
-    let configurationStr = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION;
-    if (!configurationStr) {
-      const configurationFile = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE;
-      if (configurationFile) {
+  let configurationStr = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION;
+  if (!configurationStr) {
+    const configurationFile = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE;
+    if (configurationFile) {
+      try {
         configurationStr = fs.readFileSync(configurationFile, "utf8");
+      } catch (e) {
+        console.log(`Error: Exception reading record/replay configuration file: ${e}`);
       }
     }
-    if (configurationStr) {
+  }
+  if (configurationStr) {
+    try {
       return JSON.parse(configurationStr);
+    } catch (e) {
+      console.log(`Error: Exception parsing record/replay configuration: ${e}`);
     }
-  } catch (e) {
-    console.log(`Error: Exception loading record/replay configuration: ${e}`);
   }
   return {};
 }

--- a/lib/exec/run.js
+++ b/lib/exec/run.js
@@ -222,9 +222,6 @@ module.exports = {
 
 };
 
-// How many recordings of a test we can create at once.
-const MaxTestRecordings = 20;
-
 // Parse the passing/failing tests from stdout data.
 function readTestsFromOutput(testOutput) {
   // Remove coloring from the output.
@@ -260,20 +257,56 @@ async function maybeRecordTests(options, testOutput) {
 
   debug(`Found tests: ${JSON.stringify(tests)}`);
 
-  let numTestRecordings = 0;
-  for (const testInfo of tests) {
-    if (shouldRecordTest(testInfo) && numTestRecordings < MaxTestRecordings) {
-      await createTestRecording(options, testInfo);
-      numTestRecordings++;
-    }
+  const configuration = loadRecordReplayConfiguration();
+  console.log(`Loaded record/replay configuration: ${JSON.stringify(configuration)}`);
+
+  let testRecordings = tests.filter(testInfo => shouldRecordTest(testInfo, configuration));
+
+  if (configuration.shuffleOrder) {
+    testRecordings = _.shuffle(testRecordings);
+  }
+
+  // How many recordings of a test we can create at once.
+  const maxRecordings = configuration.maxRecordings || 20;
+
+  if (testRecordings.length > maxRecordings) {
+    console.log(`Too many tests to record: ${testRecordings.length}, limit is ${maxRecordings}`);
+    testRecordings.length = maxRecordings;
+  }
+
+  for (const testInfo of testRecordings) {
+    await createTestRecording(options, testInfo);
   }
 }
 
-function shouldRecordTest({ passed }) {
+function loadRecordReplayConfiguration() {
+  try {
+    let configurationStr = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION;
+    if (!configurationStr) {
+      if (process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE) {
+        configurationStr = fs.readFileSync(configurationFile, "utf8");
+      }
+    }
+    if (configurationStr) {
+      return JSON.parse(configurationStr);
+    }
+  } catch (e) {
+    console.log(`Error: Could not read record/replay cypress configuration file ${configurationFile}: ${e}`);
+  }
+  return {};
+}
+
+function shouldRecordTest({ title, passed }, configuration) {
+  if (configuration.recordAll) {
+    return true;
+  }
+  if (configuration.titleFilters) {
+    return configuration.titleFilters.some(filter => title.includes(filter));
+  }
   return !passed;
 }
 
-async function createTestRecording(options, { spec, title }) {
+async function createTestRecording(options, { spec, title, passed }) {
   console.log("\n");
   console.log("====================================================================================================");
   console.log(`Creating Test Recording: ${spec} "${title}"`);
@@ -390,8 +423,9 @@ for (const property of ["skip", "only"]) {
     // killed properly.
     killProcessAndTransitiveSubprocesses(childProcess.pid);
 
+    // If the test originally failed, only use the recording if it also failed.
     const tests = readTestsFromOutput(testOutput);
-    if (!tests.some(test => !test.passed)) {
+    if (!passed && !tests.some(test => !test.passed)) {
       console.log("Error: No test failures while recording, skipping upload.");
       return;
     }

--- a/lib/exec/run.js
+++ b/lib/exec/run.js
@@ -283,7 +283,8 @@ function loadRecordReplayConfiguration() {
   try {
     let configurationStr = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION;
     if (!configurationStr) {
-      if (process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE) {
+      const configurationFile = process.env.RECORD_REPLAY_CYPRESS_CONFIGURATION_FILE;
+      if (configurationFile) {
         configurationStr = fs.readFileSync(configurationFile, "utf8");
       }
     }
@@ -291,7 +292,7 @@ function loadRecordReplayConfiguration() {
       return JSON.parse(configurationStr);
     }
   } catch (e) {
-    console.log(`Error: Could not read record/replay cypress configuration file ${configurationFile}: ${e}`);
+    console.log(`Error: Exception loading record/replay configuration: ${e}`);
   }
   return {};
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/cypress",
-  "version": "9.2.3",
+  "version": "9.2.4",
   "main": "index.js",
   "scripts": {
     "postinstall": "node index.js --exec install",


### PR DESCRIPTION
…ate recordings for

Currently with Cypress we only record failing tests, and can only record up to 20 of them.  This allows a configuration file or env var to be specified to override this behavior in various ways.  Needed for https://github.com/RecordReplay/backend/issues/4421